### PR TITLE
corrigido display do IRA após múltiplos cliques

### DIFF
--- a/quest.js
+++ b/quest.js
@@ -61,6 +61,7 @@ $("document").ready(function (){
 		}
 
 		ira = ira*s1/s2;
+		$("#calcula .input").remove();
 		$("#calcula").append("<span class='input'>O seu IRA individual é "+ira+"</span>");
 
 	}	


### PR DESCRIPTION
Se o usuário clicasse várias vezes no botão de calcular, mudando informações no formulário ou não, era escrito novamente o resultado, ao lado do(s) já existente(s). Corrigido aplicando um .remove() nos elementos da classe correspondente antes do .append() do novo elemento.